### PR TITLE
Logging implementation.

### DIFF
--- a/Assets/_Project/Scripts/Tools.meta
+++ b/Assets/_Project/Scripts/Tools.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 9075793d65154f8a90af7107e220dc46
+timeCreated: 1641147746

--- a/Assets/_Project/Scripts/Tools/TextLogger.meta
+++ b/Assets/_Project/Scripts/Tools/TextLogger.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 56e9a7d87f5c41a4b78db6554d5b7eca
+timeCreated: 1641148149

--- a/Assets/_Project/Scripts/Tools/TextLogger/DummyLogger.cs
+++ b/Assets/_Project/Scripts/Tools/TextLogger/DummyLogger.cs
@@ -1,0 +1,13 @@
+﻿namespace PolSl.UrbanHealthPath.Tools.TextLogger
+{
+    public class DummyLogger : ITextLogger
+    {
+        public void Log(LogVerbosity verbosity, string message)
+        {
+        }
+
+        public void Log(LogVerbosity verbosity, string category, string message)
+        {
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Tools/TextLogger/DummyLogger.cs.meta
+++ b/Assets/_Project/Scripts/Tools/TextLogger/DummyLogger.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a993474069d04cc5868f1a99534984fd
+timeCreated: 1641149052

--- a/Assets/_Project/Scripts/Tools/TextLogger/ITextLogger.cs
+++ b/Assets/_Project/Scripts/Tools/TextLogger/ITextLogger.cs
@@ -1,0 +1,8 @@
+﻿namespace PolSl.UrbanHealthPath.Tools.TextLogger
+{
+    public interface ITextLogger
+    {
+        void Log(LogVerbosity verbosity, string message);
+        void Log(LogVerbosity verbosity, string category, string message);
+    }
+}

--- a/Assets/_Project/Scripts/Tools/TextLogger/ITextLogger.cs.meta
+++ b/Assets/_Project/Scripts/Tools/TextLogger/ITextLogger.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 10cdd3702f03414c813cb42baf288ff7
+timeCreated: 1641147765

--- a/Assets/_Project/Scripts/Tools/TextLogger/LogVerbosity.cs
+++ b/Assets/_Project/Scripts/Tools/TextLogger/LogVerbosity.cs
@@ -1,0 +1,11 @@
+﻿namespace PolSl.UrbanHealthPath.Tools.TextLogger
+{
+    public enum LogVerbosity
+    {
+        Debug = 0,
+        Log = 10,
+        Warning = 100,
+        Error = 1000,
+        Fatal = 10000,
+    }
+}

--- a/Assets/_Project/Scripts/Tools/TextLogger/LogVerbosity.cs.meta
+++ b/Assets/_Project/Scripts/Tools/TextLogger/LogVerbosity.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: c3c227fbc39b44e9abf52cfad9103c36
+timeCreated: 1641148184

--- a/Assets/_Project/Scripts/Tools/TextLogger/UnityLogger.cs
+++ b/Assets/_Project/Scripts/Tools/TextLogger/UnityLogger.cs
@@ -1,0 +1,47 @@
+﻿using UnityEngine;
+
+namespace PolSl.UrbanHealthPath.Tools.TextLogger
+{
+    public class UnityLogger : ITextLogger
+    {
+        private const string DEFAULT_CATEGORY = "default";
+        
+        public void Log(LogVerbosity verbosity, string message)
+        {
+            Log(verbosity, DEFAULT_CATEGORY, message);
+        }
+
+        public void Log(LogVerbosity verbosity, string category, string message)
+        {
+            string messageWithCategory = $"[{category}] {message}";
+
+            if (verbosity >= LogVerbosity.Error)
+            {
+                LogError(messageWithCategory);
+            }
+            else if (verbosity >= LogVerbosity.Warning)
+            {
+                LogWarning(messageWithCategory);
+            }
+            else
+            {
+                LogDebug(messageWithCategory);
+            }
+        }
+
+        private void LogDebug(string message)
+        {
+            Debug.Log(message);
+        }
+
+        private void LogWarning(string message)
+        {
+            Debug.LogWarning(message);
+        }
+
+        private void LogError(string message)
+        {
+            Debug.LogError(message);
+        }
+    }
+}

--- a/Assets/_Project/Scripts/Tools/TextLogger/UnityLogger.cs.meta
+++ b/Assets/_Project/Scripts/Tools/TextLogger/UnityLogger.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 0e3429a427024dd8b48301bd2f5ebd4c
+timeCreated: 1641148429


### PR DESCRIPTION
Basic logging implementation using Unity's Debug.Log feature.
Every class that requires logging something should add ITextLogger as a parameter in constructor.

This solution should enable us to easily swap implementations and make use of decorators. We can think about adding factories later on (GetDevelopmentLogger, GetProductionLogger etc.).